### PR TITLE
Raise error if detected when creating certificate (and a cry for help)

### DIFF
--- a/lib/cupertino/provisioning_portal/agent.rb
+++ b/lib/cupertino/provisioning_portal/agent.rb
@@ -172,6 +172,10 @@ module Cupertino
           form.field_with(name: "appIdId").value = extra_id
         end
         form.submit
+
+        if error = page.search('.errorMessage').first
+          raise error.text.strip
+        end
         #TODO: Handle this more gracefully with a return ID of some sort.
       end
 


### PR DESCRIPTION
Hi there. First of all, it's great that you've added in all these extra features on top of the original version of this gem - I thought I was going to have to do exactly the same when I discovered your repo from the network graph. So thanks a lot, you've saved me a huge amount of time!

This is part mini-pull-request and part issue, as you don't have issues enabled on your repo.

The pull-request part of it is just some error checking when uploading a CSR during certificate creation. If the page returns with an error message, it detects it and raises it. I put this in because I was coming across an error when trying to create a production push certificate. So this leads me on to the issue part...

Basically, I get an error saying "Invalid certificate request type" when trying to create a production push certificate. It gets to the final form of the process, but where you select a CSR to upload, the submitted file doesn't seem to work. If I do this process manually and use exactly the same CSR then it works.

I've tried passing in a relative and absolute file path, but no luck. 
## Breaking news!!11!!one

I've just tried creating a normal certificate simply using `ios certificates:create path/to/my.csr` and it fails with the same error message.

So my question is this - is it only me or are you finding the same problem?
